### PR TITLE
Fix missing hero image 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Learn Vanilla JavaScript
 
-![vanilla-js](https://snipcart.com/media/203715/vanilla-js.jpeg)
+![vanilla-js](https://user-images.githubusercontent.com/2788192/141443411-e7fbdea4-f8cf-4aa0-8347-526a47fa9197.png)
 
 An open source list of paid &amp; free resources to learn vanilla JavaScript.
 


### PR DESCRIPTION
The hero image returned a 404 not found.

The Wayback Machine shows how it used to look: https://web.archive.org/web/20210901205904/https://github.com/snipcart/learn-vanilla-js

So I recreated the hero image. It's currently hosted on `user-images.githubusercontent.com`. Feel free to host/link it somewhere else.