### PR TITLE
Update vanilla js frontend masters course links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ An open source list of paid &amp; free resources to learn vanilla JavaScript.
 
 - [JavaScript: Understanding the Weird Parts](https://www.udemy.com/understand-javascript/) by [Anthony Alicea](https://twitter.com/anthonypalicea) 💰
 - [Modern JavaScript From The Beginning](https://www.udemy.com/modern-javascript-from-the-beginning/) by [Brad Traversy](https://twitter.com/traversymedia) 💰
-- [Introduction to JavaScript Programming](https://frontendmasters.com/courses/javascript-basics/) by [Kyle Simpson](https://twitter.com/getify) 💰
+- [Getting Started with JavaScript](https://frontendmasters.com/courses/getting-started-javascript-v2/) by [Kyle Simpson](https://twitter.com/getify)
+- [JavaScript: The Hard Parts](https://frontendmasters.com/courses/javascript-hard-parts-v2/) by [Will Sentance](https://twitter.com/willsentance) 💰
+- [JavaScript Learning Path](https://frontendmasters.com/learn/javascript/) by [Frontend Masters](https://frontendmasters.com/) 💰
 - [The Creative Javascript Course](https://developedbyed.com/p/the-creative-javascript-course) by [Dev Ed](https://twitter.com/developedbyed) 💰
 - [JavaScript 30](https://javascript30.com/) by [Wes Bos](https://twitter.com/wesbos)
 - [Practical JavaScript](https://watchandcode.com/p/practical-javascript) by [Gordon Zhu](https://twitter.com/gordon_zhu)


### PR DESCRIPTION
- Updated link to Kyle Simpson's latest "Getting Started with JavaScript" course (also this is a free course): https://frontendmasters.com/courses/getting-started-javascript-v2/
- Added Will Sentance's "JavaScript: The Hard Parts" course which is the most popular vanilla JavaScript course on Frontend Masters https://frontendmasters.com/courses/javascript-hard-parts-v2/
- Added link to the full JavaScript learning path which is eight courses in order on vanilla JavaScript: https://frontendmasters.com/learn/javascript/